### PR TITLE
Fix flex delegates for TF lite 2.11.1 

### DIFF
--- a/tensorflow/lite/core/interpreter.h
+++ b/tensorflow/lite/core/interpreter.h
@@ -117,7 +117,7 @@ class Interpreter {
   // used. Ownership of 'error_reporter' remains with the caller.
   // WARNING: Use of this constructor outside of an InterpreterBuilder is not
   // recommended.
-Interpreter(const HMODULE& flex_dll, ErrorReporter* error_reporter = DefaultErrorReporter());
+Interpreter(const HMODULE flex_dll, ErrorReporter* error_reporter = DefaultErrorReporter());
 
   ~Interpreter();
 
@@ -740,7 +740,7 @@ Interpreter(const HMODULE& flex_dll, ErrorReporter* error_reporter = DefaultErro
   ErrorReporter* error_reporter() const { return error_reporter_; }
 
  private:
-  const HMODULE& flex_dll_;
+  HMODULE const flex_dll_;
   friend class InterpreterBuilder;
   friend class tflite::InterpreterTest;
   friend class tflite::delegates::InterpreterUtils;

--- a/tensorflow/lite/core/interpreter.h
+++ b/tensorflow/lite/core/interpreter.h
@@ -23,7 +23,9 @@ limitations under the License.
 
 // IWYU pragma: private, include "third_party/tensorflow/lite/interpreter.h"
 // IWYU pragma: friend third_party/tensorflow/lite/interpreter.h
-
+#include <windows.h>
+#undef max
+#undef min
 #include <stddef.h>
 #include <stdint.h>
 
@@ -115,7 +117,7 @@ class Interpreter {
   // used. Ownership of 'error_reporter' remains with the caller.
   // WARNING: Use of this constructor outside of an InterpreterBuilder is not
   // recommended.
-Interpreter(const std::wstring& flex_dll_path_, ErrorReporter* error_reporter = DefaultErrorReporter());
+Interpreter(const HMODULE& flex_dll, ErrorReporter* error_reporter = DefaultErrorReporter());
 
   ~Interpreter();
 
@@ -738,7 +740,7 @@ Interpreter(const std::wstring& flex_dll_path_, ErrorReporter* error_reporter = 
   ErrorReporter* error_reporter() const { return error_reporter_; }
 
  private:
-  const std::wstring flex_dll_path_;
+  const HMODULE& flex_dll_;
   friend class InterpreterBuilder;
   friend class tflite::InterpreterTest;
   friend class tflite::delegates::InterpreterUtils;

--- a/tensorflow/lite/core/interpreter.h
+++ b/tensorflow/lite/core/interpreter.h
@@ -115,7 +115,7 @@ class Interpreter {
   // used. Ownership of 'error_reporter' remains with the caller.
   // WARNING: Use of this constructor outside of an InterpreterBuilder is not
   // recommended.
-  explicit Interpreter(ErrorReporter* error_reporter = DefaultErrorReporter());
+Interpreter(const std::wstring& flex_dll_path_, ErrorReporter* error_reporter = DefaultErrorReporter());
 
   ~Interpreter();
 
@@ -738,6 +738,7 @@ class Interpreter {
   ErrorReporter* error_reporter() const { return error_reporter_; }
 
  private:
+  const std::wstring flex_dll_path_;
   friend class InterpreterBuilder;
   friend class tflite::InterpreterTest;
   friend class tflite::delegates::InterpreterUtils;

--- a/tensorflow/lite/interpreter.cc
+++ b/tensorflow/lite/interpreter.cc
@@ -86,7 +86,7 @@ TfLiteQuantization GetQuantizationFromLegacy(
 
 }  // namespace
 
-Interpreter::Interpreter(const HMODULE& flex_dll, ErrorReporter* error_reporter)
+Interpreter::Interpreter(const HMODULE flex_dll, ErrorReporter* error_reporter)
     : flex_dll_(flex_dll), error_reporter_(error_reporter ? error_reporter
                                      : DefaultErrorReporter()) {
   // TODO(b/128420794): Include the TFLite runtime version in the log.

--- a/tensorflow/lite/interpreter.cc
+++ b/tensorflow/lite/interpreter.cc
@@ -14,7 +14,6 @@ limitations under the License.
 ==============================================================================*/
 
 #include "tensorflow/lite/core/interpreter.h"
-
 #include <stddef.h>
 #include <stdlib.h>
 
@@ -87,8 +86,8 @@ TfLiteQuantization GetQuantizationFromLegacy(
 
 }  // namespace
 
-Interpreter::Interpreter(const std::wstring& flex_dll_path, ErrorReporter* error_reporter)
-    : flex_dll_path_(flex_dll_path), error_reporter_(error_reporter ? error_reporter
+Interpreter::Interpreter(const HMODULE& flex_dll, ErrorReporter* error_reporter)
+    : flex_dll_(flex_dll), error_reporter_(error_reporter ? error_reporter
                                      : DefaultErrorReporter()) {
   // TODO(b/128420794): Include the TFLite runtime version in the log.
   // Prod logging is useful for mobile platforms where scraping console logs is

--- a/tensorflow/lite/interpreter.cc
+++ b/tensorflow/lite/interpreter.cc
@@ -87,8 +87,8 @@ TfLiteQuantization GetQuantizationFromLegacy(
 
 }  // namespace
 
-Interpreter::Interpreter(ErrorReporter* error_reporter)
-    : error_reporter_(error_reporter ? error_reporter
+Interpreter::Interpreter(const std::wstring& flex_dll_path, ErrorReporter* error_reporter)
+    : flex_dll_path_(flex_dll_path), error_reporter_(error_reporter ? error_reporter
                                      : DefaultErrorReporter()) {
   // TODO(b/128420794): Include the TFLite runtime version in the log.
   // Prod logging is useful for mobile platforms where scraping console logs is

--- a/tensorflow/lite/interpreter_builder.cc
+++ b/tensorflow/lite/interpreter_builder.cc
@@ -159,7 +159,7 @@ constexpr const char* kEmptyTensorName = "";
 // delegate simply by adding it as a dependency.
 // For flex delegate, see also the strong override in
 // lite/delegates/flex/delegate.cc.
-TFLITE_ATTRIBUTE_WEAK Interpreter::TfLiteDelegatePtr AcquireFlexDelegate(const HMODULE& flex_dll) {
+TFLITE_ATTRIBUTE_WEAK Interpreter::TfLiteDelegatePtr AcquireFlexDelegate(const HMODULE flex_dll) {
   // TF_AcquireFlexDelegate isn't defined on Android, and the following block of
   // code would have no effect if TF_AcquireFlexDelegate isn't defined, so we
   // only enable that block for non-Android platforms.  Also, on Android 4.4

--- a/tensorflow/lite/interpreter_builder.cc
+++ b/tensorflow/lite/interpreter_builder.cc
@@ -159,7 +159,7 @@ constexpr const char* kEmptyTensorName = "";
 // delegate simply by adding it as a dependency.
 // For flex delegate, see also the strong override in
 // lite/delegates/flex/delegate.cc.
-TFLITE_ATTRIBUTE_WEAK Interpreter::TfLiteDelegatePtr AcquireFlexDelegate(const std::wstring& dll_path_string) {
+TFLITE_ATTRIBUTE_WEAK Interpreter::TfLiteDelegatePtr AcquireFlexDelegate(const HMODULE& flex_dll) {
   // TF_AcquireFlexDelegate isn't defined on Android, and the following block of
   // code would have no effect if TF_AcquireFlexDelegate isn't defined, so we
   // only enable that block for non-Android platforms.  Also, on Android 4.4
@@ -168,10 +168,9 @@ TFLITE_ATTRIBUTE_WEAK Interpreter::TfLiteDelegatePtr AcquireFlexDelegate(const s
   // important that on Android 4.4 we *don't* call SharedLibrary::GetSymbol
   // unless the symbol is sure to exist.
 #if !defined(__ANDROID__)
-
   auto acquire_flex_delegate_func =
       reinterpret_cast<Interpreter::TfLiteDelegatePtr (*)()>(
-          SharedLibrary::GetSymbol2(SharedLibrary::LoadLibrary(dll_path_string.c_str()), "TF_AcquireFlexDelegate"));
+          SharedLibrary::GetSymbol2(flex_dll, "TF_AcquireFlexDelegate"));
   if (acquire_flex_delegate_func) {
     return acquire_flex_delegate_func();
   }
@@ -671,7 +670,7 @@ TfLiteStatus InterpreterBuilder::ParseTensors(
 TfLiteStatus InterpreterBuilder::ApplyDelegates(Interpreter* interpreter) {
   // Apply Flex delegate if applicable.
   if (has_flex_op_) {
-    if (Interpreter::TfLiteDelegatePtr flex_delegate = AcquireFlexDelegate(interpreter->flex_dll_path_)) {
+    if (Interpreter::TfLiteDelegatePtr flex_delegate = AcquireFlexDelegate(interpreter->flex_dll_)) {
       TF_LITE_ENSURE_STATUS(interpreter->ModifyGraphWithDelegateImpl(
           // Transfers ownership of flex_delegate to the interpreter.
           std::move(flex_delegate)));
@@ -757,7 +756,7 @@ TfLiteStatus InterpreterBuilder::operator()(
     return cleanup_and_error();
   }
 
-  *interpreter = std::make_unique<Interpreter>((*interpreter)->flex_dll_path_, error_reporter_);
+  *interpreter = std::make_unique<Interpreter>((*interpreter)->flex_dll_, error_reporter_);
   if (subgraphs->size() > 1) {
     (*interpreter)->AddSubgraphs(subgraphs->size() - 1);
   }

--- a/tensorflow/lite/interpreter_builder.cc
+++ b/tensorflow/lite/interpreter_builder.cc
@@ -159,7 +159,7 @@ constexpr const char* kEmptyTensorName = "";
 // delegate simply by adding it as a dependency.
 // For flex delegate, see also the strong override in
 // lite/delegates/flex/delegate.cc.
-TFLITE_ATTRIBUTE_WEAK Interpreter::TfLiteDelegatePtr AcquireFlexDelegate() {
+TFLITE_ATTRIBUTE_WEAK Interpreter::TfLiteDelegatePtr AcquireFlexDelegate(const std::wstring& dll_path_string) {
   // TF_AcquireFlexDelegate isn't defined on Android, and the following block of
   // code would have no effect if TF_AcquireFlexDelegate isn't defined, so we
   // only enable that block for non-Android platforms.  Also, on Android 4.4
@@ -168,9 +168,10 @@ TFLITE_ATTRIBUTE_WEAK Interpreter::TfLiteDelegatePtr AcquireFlexDelegate() {
   // important that on Android 4.4 we *don't* call SharedLibrary::GetSymbol
   // unless the symbol is sure to exist.
 #if !defined(__ANDROID__)
+
   auto acquire_flex_delegate_func =
       reinterpret_cast<Interpreter::TfLiteDelegatePtr (*)()>(
-          SharedLibrary::GetSymbol("TF_AcquireFlexDelegate"));
+          SharedLibrary::GetSymbol2(SharedLibrary::LoadLibrary(dll_path_string.c_str()), "TF_AcquireFlexDelegate"));
   if (acquire_flex_delegate_func) {
     return acquire_flex_delegate_func();
   }
@@ -670,7 +671,7 @@ TfLiteStatus InterpreterBuilder::ParseTensors(
 TfLiteStatus InterpreterBuilder::ApplyDelegates(Interpreter* interpreter) {
   // Apply Flex delegate if applicable.
   if (has_flex_op_) {
-    if (Interpreter::TfLiteDelegatePtr flex_delegate = AcquireFlexDelegate()) {
+    if (Interpreter::TfLiteDelegatePtr flex_delegate = AcquireFlexDelegate(interpreter->flex_dll_path_)) {
       TF_LITE_ENSURE_STATUS(interpreter->ModifyGraphWithDelegateImpl(
           // Transfers ownership of flex_delegate to the interpreter.
           std::move(flex_delegate)));
@@ -756,7 +757,7 @@ TfLiteStatus InterpreterBuilder::operator()(
     return cleanup_and_error();
   }
 
-  *interpreter = std::make_unique<Interpreter>(error_reporter_);
+  *interpreter = std::make_unique<Interpreter>((*interpreter)->flex_dll_path_, error_reporter_);
   if (subgraphs->size() > 1) {
     (*interpreter)->AddSubgraphs(subgraphs->size() - 1);
   }

--- a/tensorflow/lite/shared_library.h
+++ b/tensorflow/lite/shared_library.h
@@ -38,7 +38,7 @@ class SharedLibrary {
   }
   // Warning: Unlike dlsym(RTLD_DEFAULT), it doesn't search the symbol from
   // dependent DLLs.
-  static inline void* GetSymbol2(const HMODULE& handle, const char* symbol) {
+  static inline void* GetSymbol2(const HMODULE handle, const char* symbol) {
     return reinterpret_cast<void*>(GetProcAddress(handle, symbol));
   }
   static inline void* GetSymbol(const char* symbol) {

--- a/tensorflow/lite/shared_library.h
+++ b/tensorflow/lite/shared_library.h
@@ -38,8 +38,8 @@ class SharedLibrary {
   }
   // Warning: Unlike dlsym(RTLD_DEFAULT), it doesn't search the symbol from
   // dependent DLLs.
-  static inline void* GetSymbol2(void* handle, const char* symbol) {
-    return reinterpret_cast<void*>(GetProcAddress(static_cast<HMODULE>(handle), symbol));
+  static inline void* GetSymbol2(const HMODULE& handle, const char* symbol) {
+    return reinterpret_cast<void*>(GetProcAddress(handle, symbol));
   }
   static inline void* GetSymbol(const char* symbol) {
     return reinterpret_cast<void*>(GetProcAddress(nullptr, symbol));

--- a/tensorflow/lite/shared_library.h
+++ b/tensorflow/lite/shared_library.h
@@ -38,6 +38,9 @@ class SharedLibrary {
   }
   // Warning: Unlike dlsym(RTLD_DEFAULT), it doesn't search the symbol from
   // dependent DLLs.
+  static inline void* GetSymbol2(void* handle, const char* symbol) {
+    return reinterpret_cast<void*>(GetProcAddress(static_cast<HMODULE>(handle), symbol));
+  }
   static inline void* GetSymbol(const char* symbol) {
     return reinterpret_cast<void*>(GetProcAddress(nullptr, symbol));
   }


### PR DESCRIPTION
Fix flex delegates for TF lite 2.11.1 by supplying dll path of flex dll

Just making sure there are no issues with my fix... we shouldn't have to maintain this code as I've reported this issue to the tensorflow team